### PR TITLE
Validate config with ocvalidate from OpenCore

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,6 @@ jobs:
       - uses: brokeyourbike/ocvalidate-action@v0.3
         with:
           opencore-version: '0.9.3'
+          release: false
 
       - run: ocvalidate EFI/OC/config.plist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  ocvalidate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: brokeyourbike/ocvalidate-action@v0.3
+        with:
+          opencore-version: '0.9.3'
+
+      - run: ocvalidate EFI/OC/config.plist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
 
       - uses: brokeyourbike/ocvalidate-action@v0.3
         with:
-          opencore-version: '0.9.3'
-          release: false
+          opencore-version: 'latest'
 
       - run: ocvalidate EFI/OC/config.plist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,6 @@ jobs:
       - uses: brokeyourbike/ocvalidate-action@v0.3
         with:
           opencore-version: 'latest'
+          release: false
 
       - run: ocvalidate EFI/OC/config.plist


### PR DESCRIPTION
It uses `latest` version to test against 0.9.3 because it was not released yet. But usually it's a good idea to specify exact version.